### PR TITLE
…

### DIFF
--- a/src/main/java/com/myhomebe/controller/GraphQLController.java
+++ b/src/main/java/com/myhomebe/controller/GraphQLController.java
@@ -34,7 +34,7 @@ public class GraphQLController {
         graphQL = GraphQL.newGraphQL(schema).build();
     }
 
-    @PostMapping(value = "/graphql", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/api/v1/graphql", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ResponseBody
     public Map<String, Object> graphql(@RequestBody Map<String, String> request, HttpServletRequest raw) {
         ExecutionResult executionResult = graphQL.execute(ExecutionInput.newExecutionInput()

--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -13,8 +13,10 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.*;
 import java.util.List;
 import java.util.Optional;
+import java.util.Map;
 
 @Service
 public class GraphQLService {
@@ -57,8 +59,22 @@ public class GraphQLService {
   }
 
   @GraphQLMutation(name = "createProject")
-  public Project createProject(@GraphQLArgument(name = "project") Project project){
-      return projectRepository.save(project);
+  public Project createProject(@GraphQLArgument(name = "project") Map<String, String> projectData,
+                              @GraphQLArgument(name = "rooms") ArrayList<Room> roomsArray){
+    Project project = new Project();
+    project.setName(projectData.get("name"));
+    project.setDescription(projectData.get("description"));
+    project.setAddress(projectData.get("address"));
+    projectRepository.save(project);
+    List<Room> rooms=new ArrayList<Room>();
+    for (Room room : roomsArray)
+      {
+        room.setProject(project);
+        roomRepository.save(room);
+        rooms.add(room);
+      }
+    project.setRooms(rooms);
+    return project;
   }
 
   @GraphQLMutation(name = "saveProject")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,6 @@ spring.datasource.initialization-mode=always
 spring.datasource.platform=postgres
 
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/my-home-be_development
+spring.datasource.url=jdbc:postgresql://localhost:5432/my_home_be_development
 spring.datasource.username=postgres
 spring.datasource.password=

--- a/src/main/resources/static/graphiql/index.html
+++ b/src/main/resources/static/graphiql/index.html
@@ -93,7 +93,7 @@
 
       // Defines a GraphQL fetcher using the fetch API.
       function graphQLFetcher(graphQLParams) {
-        return fetch(window.location.origin + '/graphql', {
+        return fetch(window.location.origin + '/api/v1/graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
Alters development database name. Adds create project graphql endpoint with ability to create projects and rooms simultaneously.

Project w/rooms creation endpoint:
```
POST to /api/v1/graphql
body:
{ "query":"mutation { createProject (project: {name: \"House 4\", description: \"made by graphql\", address: \"another address\"}, rooms: [{name: \"new room\", type: \"new type\"}, {name: \"new room 2\", type: \"room 2 type\"}]) {id name description address rooms {id name type}}}"
}
```

![image](https://user-images.githubusercontent.com/34927114/58373900-6e58a780-7ef2-11e9-8edf-91599fca24a8.png)
