### PR TITLE
Add material

### DIFF
--- a/src/main/java/com/myhomebe/model/RoomMaterial.java
+++ b/src/main/java/com/myhomebe/model/RoomMaterial.java
@@ -10,11 +10,14 @@ import java.util.HashSet;
 import com.fasterxml.jackson.annotation.*;
 
 // Creates getters, setters, equals, hash, and toString methods
-@Data
+// @Data
 //Make object ready for storage in a JPA-based data store
 @Entity
 //Creates(?) table in postgres dB
 @Table(name = "room_materials")
+@Getter @Setter
+@NoArgsConstructor
+@ToString @EqualsAndHashCode
 
 public class RoomMaterial {
 
@@ -32,10 +35,10 @@ public class RoomMaterial {
   @ManyToOne
   @JoinColumn(name = "material_id", nullable = false)
   private Material material;
-
-  RoomMaterial() {}
-
-  RoomMaterial(String element_type) {
-    this.element_type = element_type;
-  }
+  // 
+  // RoomMaterial() {}
+  //
+  // RoomMaterial(String element_type) {
+  //   this.element_type = element_type;
+  // }
 }

--- a/src/main/java/com/myhomebe/repository/MaterialRepository.java
+++ b/src/main/java/com/myhomebe/repository/MaterialRepository.java
@@ -3,8 +3,13 @@ package com.myhomebe.repository;
 import com.myhomebe.model.Material;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
 
 @Repository
 public interface MaterialRepository extends JpaRepository<Material, Long> {
-
+  @Query("SELECT m, rm.element_type FROM Material m JOIN m.roomMaterials rm JOIN rm.room r WHERE r.id = :room_id GROUP BY rm.element_type")
+   Collection<Material> roomMaterialsByType(@Param("room_id") Long id);
 }

--- a/src/main/java/com/myhomebe/repository/RoomMaterialRepository.java
+++ b/src/main/java/com/myhomebe/repository/RoomMaterialRepository.java
@@ -1,0 +1,17 @@
+package com.myhomebe.repository;
+
+import com.myhomebe.model.RoomMaterial;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+@Repository
+public interface RoomMaterialRepository extends JpaRepository<RoomMaterial, Long> {
+  // @Query("SELECT rm.element_type, rm FROM RoomMaterial rm JOIN rm.room r JOIN rm.material m WHERE r.id = :room_id GROUP BY rm.element_type")
+  //  Collection<RoomMaterial> roomMaterialsByType(@Param("room_id") Long id);
+  @Query("SELECT rm FROM RoomMaterial rm JOIN rm.room r WHERE r.id = :room_id")
+   List<RoomMaterial> roomMaterialsByType(@Param("room_id") Long id);
+}

--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -2,9 +2,11 @@ package com.myhomebe.service;
 
 import com.myhomebe.model.Project;
 import com.myhomebe.model.Room;
+import com.myhomebe.model.RoomMaterial;
 import com.myhomebe.model.Material;
 import com.myhomebe.repository.ProjectRepository;
 import com.myhomebe.repository.RoomRepository;
+import com.myhomebe.repository.RoomMaterialRepository;
 import com.myhomebe.repository.MaterialRepository;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
@@ -17,19 +19,23 @@ import java.util.*;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class GraphQLService {
 
   private final ProjectRepository projectRepository;
   private final RoomRepository roomRepository;
+  private final RoomMaterialRepository roomMaterialRepository;
   private final MaterialRepository materialRepository;
 
   public GraphQLService(ProjectRepository projectRepository,
                         RoomRepository roomRepository,
+                        RoomMaterialRepository roomMaterialRepository,
                         MaterialRepository materialRepository) {
                           this.projectRepository = projectRepository;
                           this.roomRepository = roomRepository;
+                          this.roomMaterialRepository = roomMaterialRepository;
                           this.materialRepository = materialRepository;
                         }
 
@@ -46,6 +52,24 @@ public class GraphQLService {
   @GraphQLQuery(name = "materials")
   public List<Material> getMaterials(){
       return materialRepository.findAll();
+  }
+
+  @GraphQLQuery(name = "getRoomMaterials")
+  public Collection<Material> getRoomMaterials(@GraphQLArgument(name = "room_id") Long id){
+    return materialRepository.roomMaterialsByType(id);
+  }
+
+  // @GraphQLQuery(name = "getRoomsMaterials")
+  // public Collection<RoomMaterial> getRoomsMaterials(@GraphQLArgument(name = "room_id") Long id){
+  //   return roomMaterialRepository.roomMaterialsByType(id);
+  // }
+
+  @GraphQLQuery(name = "getRoomsMaterials")
+  public Map<String, List<Material>> getRoomsMaterials(@GraphQLArgument(name = "room_id") Long id){
+    List<RoomMaterial> room_materials = roomMaterialRepository.roomMaterialsByType(id);
+    Map<String, List<Material>> result =
+    room_materials.stream().collect(Collectors.groupingBy(RoomMaterial::getElement_type, Collectors.mapping(RoomMaterial::getMaterial, Collectors.toList())));
+    return result;
   }
 
   @GraphQLQuery(name = "project")

--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -111,6 +111,21 @@ public class GraphQLService {
     });
   }
 
+  @GraphQLMutation(name = "addRoomMaterial")
+  public Optional<RoomMaterial> addMaterialToRoom(@GraphQLArgument(name = "room_id") Long id,
+                              @GraphQLArgument(name = "element_type") String element_type,
+                              @GraphQLArgument(name = "material") Material material){
+    return roomRepository.findById(id)
+    .map(room -> {
+      Material newMaterial = materialRepository.save(material);
+      RoomMaterial roomMaterial = new RoomMaterial();
+      roomMaterial.setElement_type(element_type);
+      roomMaterial.setRoom(room);
+      roomMaterial.setMaterial(newMaterial);
+      return roomMaterialRepository.save(roomMaterial);
+    });
+  }
+
   @GraphQLMutation(name = "saveProject")
   public Project saveProject(@GraphQLArgument(name = "project") Project project){
       return projectRepository.save(project);


### PR DESCRIPTION
Can add a new material to a previously created room. 

room_id (id, material (object), and element_type (string) are supplied request fields.
The created roomElement is returned, with optional fields including element type, room information, and material information. (rooms/id/materials create).

Request body format:
```
POST to /api/v1/graphql
{ "query":"mutation{addRoomMaterial(room_id: 1, element_type: \"Flooring\", material: {name: \"new material\", vendor: \"some company\"}) {id element_type room{id name} material{id name vendor quantity}}}"
}
```
Response body format:
```
{
    "data": {
        "addRoomMaterial": {
            "id": 6,
            "element_type": "Flooring",
            "room": {
                "id": 1,
                "name": "Living Room 1"
            },
            "material": {
                "id": 8,
                "name": "new material",
                "vendor": "some company",
                "quantity": null
            }
        }
    }
}
```
![image](https://user-images.githubusercontent.com/34927114/58386391-69f8c100-7fbc-11e9-9068-ee6c6804ebf9.png)
