### PR TITLE
Room update and delete

### DIFF
--- a/src/main/java/com/myhomebe/model/Material.java
+++ b/src/main/java/com/myhomebe/model/Material.java
@@ -43,7 +43,7 @@ public class Material {
   @GraphQLQuery(name = "unit_price", description = "A material's unit price")
   private Float unit_price;
 
-  @OneToMany(mappedBy = "material")
+  @OneToMany(mappedBy = "material", orphanRemoval = true, cascade = CascadeType.PERSIST)
   @JsonIgnoreProperties("material")
   private List<RoomMaterial> roomMaterials = new ArrayList<>();
 

--- a/src/main/java/com/myhomebe/model/Room.java
+++ b/src/main/java/com/myhomebe/model/Room.java
@@ -38,25 +38,12 @@ public class Room {
   @GraphQLQuery(name = "description", description = "A room's description")
   private String description;
 
-  @OneToMany(mappedBy = "room")
+  @OneToMany(mappedBy = "room", orphanRemoval = true, cascade = CascadeType.ALL)
   @JsonIgnoreProperties("room")
   private List<RoomMaterial> roomMaterials = new ArrayList<>();
 
-
-  // @JsonIgnoreProperties("room")
-  // Set<RoomMaterial> materials;
-
-  // @ManyToMany(cascade = CascadeType.ALL)
-  // @JoinTable(
-  //   name = "room_materials",
-  //   joinColumns = @JoinColumn(name = "room_id", referencedColumnName = "id"),
-  //   inverseJoinColumns = @JoinColumn(name = "material_id", referencedColumnName = "id")
-  // )
-  // private Set<Material> materials  = new HashSet<>();
-
-  @ManyToOne(cascade = {CascadeType.ALL})
+  @ManyToOne
   @JoinColumn(name = "project_id")
-  // @JsonIgnore
   @JsonIgnoreProperties("rooms")
   Project project;
 }

--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -157,8 +157,30 @@ public class GraphQLService {
     });
   }
 
+  @GraphQLMutation(name = "updateRoom")
+  public Optional<Room> updateRoom(@GraphQLArgument(name = "room") Room updRoom){
+    return roomRepository.findById(updRoom.getId())
+    .map(room -> {
+      if (updRoom.getName() != null) {
+        room.setName(updRoom.getName());
+      }
+      if (updRoom.getType() != null) {
+        room.setType(updRoom.getType());
+      }
+      if (updRoom.getDescription() != null) {
+        room.setDescription(updRoom.getDescription());
+      }
+      return roomRepository.save(room);
+    });
+  }
+
   @GraphQLMutation(name = "deleteProject")
   public void deleteProject(@GraphQLArgument(name = "id") Long id){
     projectRepository.deleteById(id);
+  }
+
+  @GraphQLMutation(name = "deleteRoom")
+  public void deleteRoom(@GraphQLArgument(name = "id") Long id){
+    roomRepository.deleteById(id);
   }
 }


### PR DESCRIPTION
Adds update and delete room endpoints.

From project page, user can edit a specific room through a form where they fill in room details. This triggers a BE request/response. The request will supply a room object with updated fields.

Request body format:
```
POST to /api/v1/graphql
{ "query":"mutation{updateRoom(room: {id: 3, name: \"Master Bedroom\", type: \"Bedroom\", description: \"test room\"}) {id name type description roomMaterials{id}}}"
}
```
Response body format:
```
{
    "data": {
        "updateRoom": {
            "id": 3,
            "name": "Master Bedroom",
            "type": "Bedroom",
            "description": "test room",
            "roomMaterials": []
        }
    }
}
```

From project page, user can delete a specific room and associated materials. This triggers a BE request/response. The request will supply the room id. Successful response will return a null room object with a 200 status.

Request body format:
```
POST to /api/v1/graphql
{ "query":"mutation{deleteRoom(id: 3)}"
}
```
Response body format:
```
{
    "data": {
        "deleteRoom": null
    }
}
```