### PR TITLE
roomMaterial delete endpoint

### DIFF
--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -183,4 +183,9 @@ public class GraphQLService {
   public void deleteRoom(@GraphQLArgument(name = "id") Long id){
     roomRepository.deleteById(id);
   }
+
+  @GraphQLMutation(name = "deleteRoomMaterial")
+  public void deleteRoomMaterial(@GraphQLArgument(name = "id") Long id){
+    roomMaterialRepository.deleteById(id);
+  }
 }


### PR DESCRIPTION
From room material side drawer on project page, user can elect to delete a specific material. The RoomMaterial id corresponding to the given room and selected material is sent in a BE request/response. (rooms/id/materials/id delete).

Request body format:
```
POST to api/v1/graphql
{ "query":"mutation{deleteRoomMaterial(id: 3)}"
}
```
Response body format:
```
{
  "data": {
    "deleteRoomMaterial": null
  }
}
```
![image](https://user-images.githubusercontent.com/34927114/58396525-4bb9b200-800a-11e9-9774-0971483efd36.png)
