### PR TITLE
Adds update room material endpoint

### DIFF
--- a/src/main/java/com/myhomebe/controller/ProjectController.java
+++ b/src/main/java/com/myhomebe/controller/ProjectController.java
@@ -5,7 +5,6 @@ import com.myhomebe.repository.ProjectRepository;
 import com.myhomebe.exceptions.NotFoundException;
 import com.myhomebe.exceptions.NotFoundAdvice;
 
-// import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-// import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/myhomebe/model/Material.java
+++ b/src/main/java/com/myhomebe/model/Material.java
@@ -13,12 +13,13 @@ import java.util.ArrayList;
 import io.leangen.graphql.annotations.GraphQLQuery;
 
 
-// Creates getters, setters, equals, hash, and toString methods
-@Data
 //Make object ready for storage in a JPA-based data store
 @Entity
 //Creates(?) table in postgres dB
 @Table(name = "materials")
+@Getter @Setter
+@NoArgsConstructor
+@ToString @EqualsAndHashCode
 
 public class Material {
 
@@ -47,17 +48,17 @@ public class Material {
   @JsonIgnoreProperties("material")
   private List<RoomMaterial> roomMaterials = new ArrayList<>();
 
-  Material() {}
-
-  Material(String name, String model_number, String brand, String vendor,
-          String manual_url, String notes, Float quantity, Float unit_price) {
-    this.name = name;
-    this.model_number = model_number;
-    this.brand = brand;
-    this.vendor = vendor;
-    this.manual_url = manual_url;
-    this.notes = notes;
-    this.quantity = quantity;
-    this.unit_price = unit_price;
-  }
+  // Material() {}
+  //
+  // Material(String name, String model_number, String brand, String vendor,
+  //         String manual_url, String notes, Float quantity, Float unit_price) {
+  //   this.name = name;
+  //   this.model_number = model_number;
+  //   this.brand = brand;
+  //   this.vendor = vendor;
+  //   this.manual_url = manual_url;
+  //   this.notes = notes;
+  //   this.quantity = quantity;
+  //   this.unit_price = unit_price;
+  // }
 }

--- a/src/main/java/com/myhomebe/service/GraphQLService.java
+++ b/src/main/java/com/myhomebe/service/GraphQLService.java
@@ -174,6 +174,48 @@ public class GraphQLService {
     });
   }
 
+  @GraphQLMutation(name = "updateProjectMaterial")
+  public Optional<RoomMaterial> updateProjectMaterial(@GraphQLArgument(name = "roomMaterial_id") Long id,
+                                                  @GraphQLArgument(name = "element_type") String element_type,
+                                                  @GraphQLArgument(name = "material") Material updMaterial){
+    return roomMaterialRepository.findById(id)
+      // or else throw not found exception
+    .map(rm -> {
+      Material material = rm.getMaterial();
+      if (updMaterial != null) {
+        if (updMaterial.getName() != null) {
+          material.setName(updMaterial.getName());
+        }
+        if (updMaterial.getModel_number() != null) {
+          material.setModel_number(updMaterial.getModel_number());
+        }
+        if (updMaterial.getBrand() != null) {
+          material.setBrand(updMaterial.getBrand());
+        }
+        if (updMaterial.getVendor() != null) {
+          material.setVendor(updMaterial.getVendor());
+        }
+        if (updMaterial.getManual_url() != null) {
+          material.setManual_url(updMaterial.getManual_url());
+        }
+        if (updMaterial.getNotes() != null) {
+          material.setNotes(updMaterial.getNotes());
+        }
+        if (updMaterial.getQuantity() != null) {
+          material.setQuantity(updMaterial.getQuantity());
+        }
+        if (updMaterial.getUnit_price() != null) {
+          material.setUnit_price(updMaterial.getUnit_price());
+        }
+      }
+      if (element_type != null) {
+        rm.setElement_type(element_type);
+      }
+      materialRepository.save(material);
+      return roomMaterialRepository.save(rm);
+    });
+  }
+
   @GraphQLMutation(name = "deleteProject")
   public void deleteProject(@GraphQLArgument(name = "id") Long id){
     projectRepository.deleteById(id);


### PR DESCRIPTION
Adds endpoint for updating a room material (global material). Can edit just element_type and/or any element fields. Element fields update all project elements regardless of room (not just the room instance - this is planned for a future endpoint).

From room material side drawer on project page, user can elect to edit a specific material. The selected roomElement id must be supplied, along with optional fields of the element type and an updated material object including updated information is sent in a BE request/response. (rooms/id/roommaterial/id update).

Request body format:
```
POST to /api/v1/graphql
{ "query":"mutation{updateProjectMaterial(roomMaterial_id: 1, element_type: \"Flooring\", material: {name: \"Updated material\", brand: \"Updated Brand\"}) {id element_type material{name brand vendor manual_url unit_price quantity model_number notes}}}"
}
```
Response body format:
```
{
    "data": {
        "updateProjectMaterial": {
            "id": 1,
            "element_type": "Flooring",
            "material": {
                "name": "Updated material",
                "brand": "Updated Brand",
                "vendor": "HD",
                "manual_url": null,
                "unit_price": null,
                "quantity": null,
                "model_number": "abc1",
                "notes": null
            }
        }
    }
}
```
![image](https://user-images.githubusercontent.com/34927114/58512552-a19d6f80-815a-11e9-97a8-8318475982e9.png)
